### PR TITLE
fixed windows script to deal with spaces

### DIFF
--- a/AfterEffectsScripting.sublime-build
+++ b/AfterEffectsScripting.sublime-build
@@ -5,7 +5,8 @@
   "shell": true,
   "windows": 
   {
-    "cmd": ["cd ${packages}\\AfterEffects\\ && build.bat $file_name $file_path"],
-    "encoding": "cp850"
+    "cmd": ["build.bat", "$file_name", "$file_path"],
+	"encoding": "cp850",
+	"working_dir": "${packages}\\After-Effects-Scripting-Sublime-Text-Package\\"
   }
 }

--- a/build.bat
+++ b/build.bat
@@ -1,16 +1,22 @@
 @echo off 
 :: Renaming arguments
 set file_name=%1%
-set file_path=%2%
+set file_path=%2% 
 
-:: Change this accordingly to your CS version
-set version=CS6
+:: Kludgy, but it works
+if EXIST "c:\Program Files\Adobe\Adobe After Effects CS5" set version=CS5
+if EXIST "c:\Program Files\Adobe\Adobe After Effects CS6" set version=CS6
+if EXIST "c:\Program Files\Adobe\Adobe After Effects CC 2014" set version=CC 2014
+if EXIST "c:\Program Files\Adobe\Adobe After Effects CC 2015" set version=CC 2015
+::for future versions, as long as adobe don't change their naming system
+if EXIST "c:\Program Files\Adobe\Adobe After Effects CC 2016" set version=CC 2016
+if EXIST "c:\Program Files\Adobe\Adobe After Effects CC 2017" set version=CC 2017
 
 :: Adobe After Effects folder location
 set base_path=c:\Program Files\Adobe
 set ae_folder_path=%base_path%\Adobe After Effects %version%
 set ae_scripts_folder_path=%ae_folder_path%\Support Files\Scripts
-
+::echo %ae_scripts_folder_path%
 
 cd "%file_path%"
 
@@ -19,7 +25,7 @@ copy "%file_name%" "%ae_scripts_folder_path%\%file_name%"
 
 cd "%ae_folder_path%\Support Files"
 
-:: Running script in After Effect
+:: Running script in After Effects
 AfterFX -r "%ae_scripts_folder_path%\%file_name%"
 
 :: Printing happy feedback in the console


### PR DESCRIPTION
The windows script didn't deal with spaces in the file or folder paths,
this is fixed.
Add a simple autodiscovery method for the version of AE you're using
(for windows only ATM).
